### PR TITLE
Replace with_mock() with with_mocked_bindings()

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -4,7 +4,7 @@ on:
     branches: main
   pull_request:
 
-name: R-CMD-check.yaml
+name: R-CMD-check
 
 permissions: read-all
 

--- a/tests/testthat/test-lsb-release.R
+++ b/tests/testthat/test-lsb-release.R
@@ -1,8 +1,8 @@
 with_mock_lsb <- function(mock, expr) {
-  with_mock(
-    `distro:::have_lsb_release` = function() TRUE,
-    `distro:::call_lsb` = function(args) mock[[args]],
-    eval.parent(expr)
+  with_mocked_bindings(
+    expr,
+    have_lsb_release = function() TRUE,
+    call_lsb = function(args) mock[[args]]
   )
 }
 
@@ -50,36 +50,81 @@ fedora_31 <- list(
 
 test_that("lsb_release", {
   with_mock_lsb(debian_bookworm_testing, {
-    expect_equal(lsb_release(), list(id = "Debian", version = "testing", codename = "bookworm"))
-    expect_equal(distro(), list(id = "debian", version = "testing", codename = "bookworm", short_version = "12"))
+    expect_equal(
+      lsb_release(),
+      list(id = "Debian", version = "testing", codename = "bookworm")
+    )
+    expect_equal(
+      distro(),
+      list(
+        id = "debian",
+        version = "testing",
+        codename = "bookworm",
+        short_version = "12"
+      )
+    )
   })
 
   # if it codename is sid, this is always the codename of the latest unstable
   # version, and we can't map to the short version number as we don't know it
   with_mock_lsb(debian_bookworm_unstable, {
-    expect_equal(distro(), list(id = "debian", version = "unstable", codename = "sid"))
+    expect_equal(
+      distro(),
+      list(id = "debian", version = "unstable", codename = "sid")
+    )
   })
 
   with_mock_lsb(debian_bullseye_testing, {
-    expect_equal(distro(), list(id = "debian", version = "testing", codename = "bullseye", short_version = "11"))
+    expect_equal(
+      distro(),
+      list(
+        id = "debian",
+        version = "testing",
+        codename = "bullseye",
+        short_version = "11"
+      )
+    )
   })
 
   with_mock_lsb(debian_bullseye, {
-    expect_equal(distro(), list(id = "debian", version = "11", codename = "bullseye", short_version = "11"))
+    expect_equal(
+      distro(),
+      list(
+        id = "debian",
+        version = "11",
+        codename = "bullseye",
+        short_version = "11"
+      )
+    )
   })
 
   expect_equal(
     with_mock_lsb(ubuntu_xenial, distro()),
-    list(id = "ubuntu", version = "16.04", codename = "xenial", short_version = "16.04")
+    list(
+      id = "ubuntu",
+      version = "16.04",
+      codename = "xenial",
+      short_version = "16.04"
+    )
   )
 
   expect_equal(
     with_mock_lsb(centos_7, distro()),
-    list(id = "centos", version = "7.7.1908", codename = "foo", short_version = "7")
+    list(
+      id = "centos",
+      version = "7.7.1908",
+      codename = "foo",
+      short_version = "7"
+    )
   )
 
   expect_equal(
     with_mock_lsb(fedora_31, distro()),
-    list(id = "fedora", version = "31", codename = "ThirtyOne", short_version = "31")
+    list(
+      id = "fedora",
+      version = "31",
+      codename = "ThirtyOne",
+      short_version = "31"
+    )
   )
 })

--- a/tests/testthat/test-os-release.R
+++ b/tests/testthat/test-os-release.R
@@ -1,8 +1,10 @@
 with_mock_os_release <- function(file, expr) {
-  with_mock(
-    `distro:::have_lsb_release` = function() FALSE, # Make sure we don't call lsb_release
-    `distro:::read_os_release` = function() readLines(test_path(file.path("os-release", file))),
-    eval.parent(expr)
+  with_mocked_bindings(
+    expr,
+    have_lsb_release = function() FALSE, # Make sure we don't call lsb_release
+    read_os_release = function() {
+      readLines(test_path(file.path("os-release", file)))
+    }
   )
 }
 

--- a/tests/testthat/test-system-release.R
+++ b/tests/testthat/test-system-release.R
@@ -1,15 +1,20 @@
 with_mock_system_release <- function(string, expr) {
-  with_mock(
-    `distro:::have_lsb_release` = function() FALSE, # Make sure we don't call lsb_release
-    `distro:::read_os_release` = function() NULL, # Or use /etc/os_release
-    `distro:::read_system_release` = function() string,
-    eval.parent(expr)
+  with_mocked_bindings(
+    expr,
+    have_lsb_release = function() FALSE, # Make sure we don't call lsb_release
+    read_os_release = function() NULL, # Or use /etc/os_release
+    read_system_release = function() string
   )
 }
 
 test_that("system_release", {
   expect_equal(
     with_mock_system_release("CentOS Linux release 7.7.1908 (Core)", distro()),
-    list(id = "centos", version = "7.7.1908", codename = NA, short_version = "7")
+    list(
+      id = "centos",
+      version = "7.7.1908",
+      codename = NA,
+      short_version = "7"
+    )
   )
 })


### PR DESCRIPTION
It's going away in the next testthat release